### PR TITLE
feat: save hyperparameters in checkpoints

### DIFF
--- a/src/snp_transformer/model/task_modules.py
+++ b/src/snp_transformer/model/task_modules.py
@@ -40,6 +40,7 @@ class EncoderForMaskedLM(TrainableModule):
         domains_to_mask: list[str] | None = None,
     ):
         super().__init__()
+        self.save_hyperparameters()
         self.initialize_model(embedding_module, encoder_module, domains_to_mask)
 
         self.loss = nn.CrossEntropyLoss(ignore_index=-1)


### PR DESCRIPTION
Otherwise, hyperparams are not saved to checkpoints: https://lightning.ai/docs/pytorch/stable/common/checkpointing_basic.html#save-hyperparameters

